### PR TITLE
Add configuration for CodeCov and format .travis.yml file

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,29 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...80"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches: null

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
-sudo: false
 language: java
+
+sudo: false
+
 jdk:
   - oraclejdk8
+
 env:
   - MVN_GOAL=test
+
 script:
   - MAVEN_OPTS=-Dorg.slf4j.simpleLogger.defaultLogLevel=info mvn org.jacoco:jacoco-maven-plugin:prepare-agent $MVN_GOAL -q -fae -Dmaven.javadoc.skip=true -DfailIfNoTests=false -B -P travis
+  - "mvn cobertura:cobertura"
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 Shell Controller - WIP
+
+[![Build status](https://travis-ci.org/servicecatalog/oscm-app-shell.svg?branch=master)](https://travis-ci.org/servicecatalog/oscm-app-shell)
+[![codecov](https://codecov.io/gh/servicecatalog/oscm-app-shell/branch/master/graph/badge.svg)](https://codecov.io/gh/servicecatalog/oscm-app-shell)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Shell Controller - WIP
+Shell Controller - WIP.
 
 [![Build status](https://travis-ci.org/servicecatalog/oscm-app-shell.svg?branch=master)](https://travis-ci.org/servicecatalog/oscm-app-shell)
 [![codecov](https://codecov.io/gh/servicecatalog/oscm-app-shell/branch/master/graph/badge.svg)](https://codecov.io/gh/servicecatalog/oscm-app-shell)

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,17 @@
             <packagingExcludes>**/ShellIntegration.docx,**/TechnicalService.xml</packagingExcludes>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>cobertura-maven-plugin</artifactId>
+          <version>2.7</version>
+          <configuration>
+            <formats>
+              <format>xml</format>
+            </formats>
+            <check />
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
I have added the configuration for CodeCov and also formated the .travis.yml file to keep the standard format used in other modules.
I added badges to the README.md file. They will show results as soon as CI passes for master branch.

Issue: https://github.com/servicecatalog/oscm-app-shell/issues/3