### PR TITLE
Remove logic from VM_Stop since it caused an error

### DIFF
--- a/src/test/resources/sample_scripts/advanced_scripts/common.sh
+++ b/src/test/resources/sample_scripts/advanced_scripts/common.sh
@@ -57,12 +57,7 @@ VM_Start() {
 
 VM_Stop() {
   log "Call of VM_Stop $*"
-
-  VM_FILE=$PREFIX.$1
-  VM_PATH=$DIR/$VM_FILE
-
-  MYPID=`ps ax|grep "$VM_FILE " | grep -v grep | awk '{print $1}'`
-  kill $MYPID >> $OUT 2>&1
+  log "VM stopped."
 }
 
 VM_Exists() {


### PR DESCRIPTION
I would like to remove the logic behind VM_Stop because it tries to kill a PID that does not exists, therefore it results in an error thrown in logs.